### PR TITLE
chore: pin GitHub Actions to commit SHAs

### DIFF
--- a/.github/workflows/deploy-demo.yaml
+++ b/.github/workflows/deploy-demo.yaml
@@ -17,11 +17,11 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4.3.1
 
       - name: Create yaml file from secret
         id: write_file
-        uses: timheuer/base64-to-file@v1
+        uses: timheuer/base64-to-file@adaa40c0c581f276132199d4cf60afa07ce60eac  # v1.2.4
         with:
           fileName: 'secret.yaml'
           encodedString: ${{ secrets.DIGDIR_FDK_INGRESS_DEMO_IPV4 }}
@@ -34,12 +34,12 @@ jobs:
           cat kubectlapply.yaml
 
       - name: Auth gcloud CLI for deploy
-        uses: google-github-actions/auth@v2
+        uses: google-github-actions/auth@c200f3691d83b41bf9bbd8638997a462592937ed  # v2.1.13
         with:
           credentials_json: ${{ secrets.DIGDIR_FDK_DEV_AUTODEPLOY }}
 
       - name: Get credentials
-        uses: google-github-actions/get-gke-credentials@v2
+        uses: google-github-actions/get-gke-credentials@64bc7249bbcf78056bb92f14d3cedc2da193946c  # v2.3.5
         with:
           cluster_name: digdir-fdk-dev
           location: europe-north1-a
@@ -49,7 +49,7 @@ jobs:
           kubectl apply -f ./kubectlapply.yaml --force
 
       - name: Notify slack
-        uses: 8398a7/action-slack@v3
+        uses: 8398a7/action-slack@77eaa4f1c608a7d68b38af4e3f739dcd8cba273e  # v3.19.0
         with:
           mention: 'channel'
           if_mention: failure
@@ -67,11 +67,11 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4.3.1
 
       - name: Create yaml file from secret
         id: write_file
-        uses: timheuer/base64-to-file@v1
+        uses: timheuer/base64-to-file@adaa40c0c581f276132199d4cf60afa07ce60eac  # v1.2.4
         with:
           fileName: 'secret.yaml'
           encodedString: ${{ secrets.DIGDIR_FDK_INGRESS_DEMO_IPV6 }}
@@ -84,12 +84,12 @@ jobs:
           cat kubectlapply.yaml
 
       - name: Auth gcloud CLI for deploy
-        uses: google-github-actions/auth@v2
+        uses: google-github-actions/auth@c200f3691d83b41bf9bbd8638997a462592937ed  # v2.1.13
         with:
           credentials_json: ${{ secrets.DIGDIR_FDK_DEV_AUTODEPLOY }}
 
       - name: Get credentials
-        uses: google-github-actions/get-gke-credentials@v2
+        uses: google-github-actions/get-gke-credentials@64bc7249bbcf78056bb92f14d3cedc2da193946c  # v2.3.5
         with:
           cluster_name: digdir-fdk-dev
           location: europe-north1-a
@@ -99,7 +99,7 @@ jobs:
           kubectl apply -f ./kubectlapply.yaml --force
 
       - name: Notify slack
-        uses: 8398a7/action-slack@v3
+        uses: 8398a7/action-slack@77eaa4f1c608a7d68b38af4e3f739dcd8cba273e  # v3.19.0
         with:
           mention: 'channel'
           if_mention: failure

--- a/.github/workflows/deploy-prod.yaml
+++ b/.github/workflows/deploy-prod.yaml
@@ -17,11 +17,11 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4.3.1
 
       - name: Create yaml file from secret
         id: write_file
-        uses: timheuer/base64-to-file@v1
+        uses: timheuer/base64-to-file@adaa40c0c581f276132199d4cf60afa07ce60eac  # v1.2.4
         with:
           fileName: 'secret.yaml'
           encodedString: ${{ secrets.DIGDIR_FDK_INGRESS_PROD_IPV4 }}
@@ -34,12 +34,12 @@ jobs:
           cat kubectlapply.yaml
 
       - name: Auth gcloud CLI for deploy
-        uses: google-github-actions/auth@v2
+        uses: google-github-actions/auth@c200f3691d83b41bf9bbd8638997a462592937ed  # v2.1.13
         with:
           credentials_json: ${{ secrets.DIGDIR_FDK_PROD_AUTODEPLOY }}
 
       - name: Get credentials
-        uses: google-github-actions/get-gke-credentials@v2
+        uses: google-github-actions/get-gke-credentials@64bc7249bbcf78056bb92f14d3cedc2da193946c  # v2.3.5
         with:
           cluster_name: digdir-fdk-prod
           location: europe-north1-a
@@ -49,7 +49,7 @@ jobs:
           kubectl apply -f ./kubectlapply.yaml --force
 
       - name: Notify slack
-        uses: 8398a7/action-slack@v3
+        uses: 8398a7/action-slack@77eaa4f1c608a7d68b38af4e3f739dcd8cba273e  # v3.19.0
         with:
           mention: 'channel'
           if_mention: failure
@@ -67,11 +67,11 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4.3.1
 
       - name: Create yaml file from secret
         id: write_file
-        uses: timheuer/base64-to-file@v1
+        uses: timheuer/base64-to-file@adaa40c0c581f276132199d4cf60afa07ce60eac  # v1.2.4
         with:
           fileName: 'secret.yaml'
           encodedString: ${{ secrets.DIGDIR_FDK_INGRESS_PROD_IPV6 }}
@@ -84,12 +84,12 @@ jobs:
           cat kubectlapply.yaml
 
       - name: Auth gcloud CLI for deploy
-        uses: google-github-actions/auth@v2
+        uses: google-github-actions/auth@c200f3691d83b41bf9bbd8638997a462592937ed  # v2.1.13
         with:
           credentials_json: ${{ secrets.DIGDIR_FDK_PROD_AUTODEPLOY }}
 
       - name: Get credentials
-        uses: google-github-actions/get-gke-credentials@v2
+        uses: google-github-actions/get-gke-credentials@64bc7249bbcf78056bb92f14d3cedc2da193946c  # v2.3.5
         with:
           cluster_name: digdir-fdk-prod
           location: europe-north1-a
@@ -99,7 +99,7 @@ jobs:
           kubectl apply -f ./kubectlapply.yaml --force
 
       - name: Notify slack
-        uses: 8398a7/action-slack@v3
+        uses: 8398a7/action-slack@77eaa4f1c608a7d68b38af4e3f739dcd8cba273e  # v3.19.0
         with:
           mention: 'channel'
           if_mention: failure

--- a/.github/workflows/deploy-staging.yaml
+++ b/.github/workflows/deploy-staging.yaml
@@ -18,11 +18,11 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4.3.1
 
       - name: Create yaml file from secret
         id: write_file
-        uses: timheuer/base64-to-file@v1
+        uses: timheuer/base64-to-file@adaa40c0c581f276132199d4cf60afa07ce60eac  # v1.2.4
         with:
           fileName: 'secret.yaml'
           encodedString: ${{ secrets.DIGDIR_FDK_INGRESS_STAGING_IPV4 }}
@@ -35,12 +35,12 @@ jobs:
           cat kubectlapply.yaml
 
       - name: Auth gcloud CLI for deploy
-        uses: google-github-actions/auth@v2
+        uses: google-github-actions/auth@c200f3691d83b41bf9bbd8638997a462592937ed  # v2.1.13
         with:
           credentials_json: ${{ secrets.DIGDIR_FDK_DEV_AUTODEPLOY }}
 
       - name: Get credentials
-        uses: google-github-actions/get-gke-credentials@v2
+        uses: google-github-actions/get-gke-credentials@64bc7249bbcf78056bb92f14d3cedc2da193946c  # v2.3.5
         with:
           cluster_name: digdir-fdk-dev
           location: europe-north1-a
@@ -50,7 +50,7 @@ jobs:
           kubectl apply -f ./kubectlapply.yaml --force
 
       - name: Notify slack
-        uses: 8398a7/action-slack@v3
+        uses: 8398a7/action-slack@77eaa4f1c608a7d68b38af4e3f739dcd8cba273e  # v3.19.0
         with:
           status: ${{ job.status }}
           author_name: 'Application: ingress(ipv4) | Environment: staging'
@@ -67,11 +67,11 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4.3.1
 
       - name: Create yaml file from secret
         id: write_file
-        uses: timheuer/base64-to-file@v1
+        uses: timheuer/base64-to-file@adaa40c0c581f276132199d4cf60afa07ce60eac  # v1.2.4
         with:
           fileName: 'secret.yaml'
           encodedString: ${{ secrets.DIGDIR_FDK_INGRESS_STAGING_IPV6 }}
@@ -84,12 +84,12 @@ jobs:
           cat kubectlapply.yaml
 
       - name: Auth gcloud CLI for deploy
-        uses: google-github-actions/auth@v2
+        uses: google-github-actions/auth@c200f3691d83b41bf9bbd8638997a462592937ed  # v2.1.13
         with:
           credentials_json: ${{ secrets.DIGDIR_FDK_DEV_AUTODEPLOY }}
 
       - name: Get credentials
-        uses: google-github-actions/get-gke-credentials@v2
+        uses: google-github-actions/get-gke-credentials@64bc7249bbcf78056bb92f14d3cedc2da193946c  # v2.3.5
         with:
           cluster_name: digdir-fdk-dev
           location: europe-north1-a
@@ -99,7 +99,7 @@ jobs:
           kubectl apply -f ./kubectlapply.yaml --force
 
       - name: Notify slack
-        uses: 8398a7/action-slack@v3
+        uses: 8398a7/action-slack@77eaa4f1c608a7d68b38af4e3f739dcd8cba273e  # v3.19.0
         with:
           status: ${{ job.status }}
           author_name: 'Application: ingress(ipv6) | Environment: staging'


### PR DESCRIPTION
# Summary

- Pin all third-party GitHub Actions to immutable commit SHAs across deploy-demo, deploy-prod, and deploy-staging workflows
- Retain current major versions for breaking-change upgrades (checkout v4, base64-to-file v1)
- Original version tags preserved as inline comments for readability